### PR TITLE
implement whitelist override feature

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ fabric_api_version=0.141.3+1.21.11
 loomVersion=1.15-SNAPSHOT
 
 # Mod Properties
-modVersion=3.8.0-1.21.11
+modVersion=3.9.0-1.21.11
 mavenGroup=de.jagenka
 archivesBaseName=diskordel
 # Kotlin

--- a/src/main/kotlin/de/jagenka/MinecraftHandler.kt
+++ b/src/main/kotlin/de/jagenka/MinecraftHandler.kt
@@ -24,7 +24,7 @@ object MinecraftHandler
     {
         this.minecraftServer = minecraftServer
 
-        minecraftServer.setUsingWhitelist(true)
+        minecraftServer.isUsingWhitelist = true
 
         Main.scope.launch {
             // make sure Diskordel user cache is filled with available data as much as possible

--- a/src/main/kotlin/de/jagenka/User.kt
+++ b/src/main/kotlin/de/jagenka/User.kt
@@ -114,3 +114,13 @@ data class MinecraftUser(var username: String, var uuid: UUID, var skinURL: Stri
 }
 
 data class DiscordUser(val id: Snowflake)
+{
+    /**
+     * checks if DiscordUser is admin - currently only allows Guild Owner to be admin
+     */
+    suspend fun isAdmin(): Boolean
+    {
+        val member = DiscordHandler.guild.getMemberOrNull(id) ?: return false
+        return member.isOwner()
+    }
+}

--- a/src/main/kotlin/de/jagenka/UserRegistry.kt
+++ b/src/main/kotlin/de/jagenka/UserRegistry.kt
@@ -16,9 +16,9 @@ import dev.kord.core.entity.effectiveName
 import info.debatty.java.stringsimilarity.Levenshtein
 import kotlinx.coroutines.launch
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents
+import net.minecraft.core.UUIDUtil
 import net.minecraft.server.players.NameAndId
 import net.minecraft.server.players.UserWhiteListEntry
-import net.minecraft.core.UUIDUtil
 import net.minecraft.world.level.storage.LevelResource
 import java.nio.file.Files
 import java.util.*
@@ -286,6 +286,17 @@ object UserRegistry
             if (nameInWhitelist !in Config.configEntry.registeredUsers.map { userInConfig -> userInConfig.minecraftName })
             {
                 minecraftServer?.playerList?.whiteList?.remove(it)
+            }
+        }
+
+        Config.configEntry.whitelistOverride.forEach { minecraftName ->
+            val profile = getGameProfile(minecraftName, true) ?: return@forEach
+
+            // not in whitelist, but should be on
+            if (minecraftServer?.playerList?.whiteList?.isWhiteListed(NameAndId(profile)) == false)
+            {
+                minecraftServer?.playerList?.whiteList?.add(UserWhiteListEntry(NameAndId(profile)))
+                logger.info("whitelisted $minecraftName")
             }
         }
     }

--- a/src/main/kotlin/de/jagenka/config/ConfigEntries.kt
+++ b/src/main/kotlin/de/jagenka/config/ConfigEntries.kt
@@ -48,7 +48,7 @@ object MinecraftUserSerializer : KSerializer<MinecraftUser>
 }
 
 /**
- * @param discordCommandCache map of internal id to Discord id
+ *
  */
 @Serializable
 class BaseConfigEntry(
@@ -56,4 +56,5 @@ class BaseConfigEntry(
     var registeredUsers: MutableList<UserEntry> = mutableListOf(),
     var userCache: MutableSet<MinecraftUser> = mutableSetOf(),
     var appCommandVersion: String = "0",
+    var whitelistOverride: MutableSet<String> = mutableSetOf(),
 )


### PR DESCRIPTION
allows Minecraft Server Admins to add a list of usernames to config, that will be whitelisted, regardless of registration in Discord. mainly used for guests, or ppl that don't use discord